### PR TITLE
port upstream_scm default branch selection to releasme where applicable

### DIFF
--- a/ci-tooling/lib/projects.rb
+++ b/ci-tooling/lib/projects.rb
@@ -93,7 +93,8 @@ class Project
   #   NB: THIS is mutually exclusive with branch!
   def initialize(name, component, url_base = self.class.default_url,
                  type: nil,
-                 branch: "kubuntu_#{type}")
+                 branch: "kubuntu_#{type}",
+                 origin: CI::UpstreamSCM::Origin::UNSTABLE)
     variable_deprecation(:type, :branch) unless type.nil?
     @name = name
     @component = component
@@ -130,6 +131,8 @@ class Project
     @override_rule.each do |member, _|
       override_apply(member)
     end
+
+    upstream_scm.releaseme_adjust!(origin) if upstream_scm
   end
 
   private

--- a/ci-tooling/lib/projects/factory/base.rb
+++ b/ci-tooling/lib/projects/factory/base.rb
@@ -22,7 +22,8 @@ class ProjectsFactory
   # Base class.
   class Base
     DEFAULT_PARAMS = {
-      branch: 'kubuntu_unstable' # FIXME: kubuntu
+      branch: 'kubuntu_unstable', # FIXME: kubuntu
+      origin: nil # Defer the origin to Project class itself
     }.freeze
 
     class << self
@@ -77,9 +78,12 @@ class ProjectsFactory
     end
 
     # FIXME: this is a workaround until Project gets entirely redone
-    def new_project(name:, component:, url_base:, branch:)
-      # puts "new_project(#{name}, #{component}, #{url_base})"
-      Project.new(name, component, url_base, branch: branch)
+    def new_project(name:, component:, url_base:, branch:, origin:)
+      params = { branch: branch }
+      # Let Project pick a default for origin, otherwise we need to retrofit
+      # all Project testing with a default which seems silly.
+      params[:origin] = origin if origin
+      Project.new(name, component, url_base, **params)
     end
   end
 end

--- a/ci-tooling/test/data/kde_projects_stripped.xml
+++ b/ci-tooling/test/data/kde_projects_stripped.xml
@@ -1,0 +1,3491 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<kdeprojects version="1">
+  <component identifier="frameworks">
+    <name>Frameworks</name>
+    <description></description>
+    <icon/>
+    <path>frameworks</path>
+    <web/>
+    <module identifier="prison">
+      <name>Barcode library</name>
+      <description>prison is a barcode api currently offering a nice Qt api to produce QRCode barcodes and DataMatrix barcodes, and can easily be made support more.</description>
+      <icon/>
+      <path>frameworks/prison</path>
+      <web>https://cgit.kde.org/prison.git</web>
+      <member username="sune">Sune Vuorela</member>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/prison.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:prison</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/prison/prison-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/prison</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/prison</url>
+        <branch>master</branch>
+        <branch>qt4</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </module>
+    <project identifier="kcmutils">
+      <name>KCMUtils</name>
+      <description>Utilities for interacting with KCModules</description>
+      <icon/>
+      <path>frameworks/kcmutils</path>
+      <web>https://cgit.kde.org/kcmutils.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kcmutils.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kcmutils</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kcmutils/kcmutils-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kcmutils</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kcmutils</url>
+        <branch>mart/KcmQml</branch>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kpackage">
+      <name>Package framework</name>
+      <description>This framework lets applications to manage user installable packages of non-binary assets</description>
+      <icon>package-applications</icon>
+      <path>frameworks/kpackage</path>
+      <web>https://cgit.kde.org/kpackage.git</web>
+      <member username="aseigo">Aaron J. Seigo</member>
+      <member username="sebas">Sebastian Kügler</member>
+      <member username="mart">Marco Martin</member>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kpackage.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kpackage</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kpackage/kpackage-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kpackage</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kpackage</url>
+        <branch>mart/kpluginmetadata</branch>
+        <branch>master</branch>
+        <branch>pluginindexer</branch>
+        <branch>sebas/index</branch>
+        <branch>sebas/kpackageindex</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kplotting">
+      <name>KPlotting</name>
+      <description>KPlotting</description>
+      <icon/>
+      <path>frameworks/kplotting</path>
+      <web>https://cgit.kde.org/kplotting.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kplotting.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kplotting</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kplotting/kplotting-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kplotting</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kplotting</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kjobwidgets">
+      <name>KJobWidgets</name>
+      <description>KJobWidgets</description>
+      <icon/>
+      <path>frameworks/kjobwidgets</path>
+      <web>https://cgit.kde.org/kjobwidgets.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kjobwidgets.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kjobwidgets</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kjobwidgets/kjobwidgets-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kjobwidgets</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kjobwidgets</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kwayland">
+      <name>KWayland</name>
+      <description>KWayland provides a Qt-style Client and Server library wrapper for the Wayland libraries.</description>
+      <icon/>
+      <path>frameworks/kwayland</path>
+      <web>https://cgit.kde.org/kwayland.git</web>
+      <member username="jriddell">Jonathan Riddell</member>
+      <member username="graesslin">Martin Gräßlin</member>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kwayland.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kwayland</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kwayland/kwayland-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kwayland</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kwayland</url>
+        <branch>Plasma/5.1</branch>
+        <branch>Plasma/5.2</branch>
+        <branch>Plasma/5.3</branch>
+        <branch>Plasma/5.4</branch>
+        <branch>Plasma/5.5</branch>
+        <branch>Plasma/5.6</branch>
+        <branch>graesslin/idle</branch>
+        <branch>graesslin/selection</branch>
+        <branch>graesslin/text-input</branch>
+        <branch>graesslin/xdg-shell</branch>
+        <branch>mart/blurProtocol</branch>
+        <branch>mart/effectsprotocol</branch>
+        <branch>master</branch>
+        <branch>sebas/kwin</branch>
+        <branch>sebas/waylandserver</branch>
+        <branch>sebas/windowmetadata</branch>
+        <branch>sebas/wl_display_sync</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kdoctools">
+      <name>KDocTools</name>
+      <description>KDocTools</description>
+      <icon/>
+      <path>frameworks/kdoctools</path>
+      <web>https://cgit.kde.org/kdoctools.git</web>
+      <member username="lueck">Burkhard Lück</member>
+      <member username="ltoscano">Luigi Toscano</member>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kdoctools.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kdoctools</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kdoctools/kdoctools-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kdoctools</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kdoctools</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kdeclarative">
+      <name>KDeclarative</name>
+      <description>KDeclarative</description>
+      <icon/>
+      <path>frameworks/kdeclarative</path>
+      <web>https://cgit.kde.org/kdeclarative.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kdeclarative.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kdeclarative</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kdeclarative/kdeclarative-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kdeclarative</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kdeclarative</url>
+        <branch>mart/KPackageView</branch>
+        <branch>mart/KcmQml</branch>
+        <branch>mart/namespace</branch>
+        <branch>mart/singleQmlEngineExperiment</branch>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kactivities">
+      <name>Activities</name>
+      <description>Core components for the KDE's Activities
+
+* Activity Manager
+  System service to manage user's activities, track the usage patterns etc.
+* KActivities library
+  API for using and interacting with the Activity Manager as a consumer,
+  application adding information to them or as an activity manager.
+* Workspace
+  Plugins for KDE workspace to easier integrate activities (KIO, etc.)</description>
+      <icon>preferences-activities</icon>
+      <path>frameworks/kactivities</path>
+      <web>https://cgit.kde.org/kactivities.git</web>
+      <member username="ivan">Ivan Čukić</member>
+      <member username="aseigo">Aaron J. Seigo</member>
+      <member username="sebas">Sebastian Kügler</member>
+      <member username="mart">Marco Martin</member>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kactivities.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kactivities</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kactivities/kactivities-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kactivities</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kactivities</url>
+        <branch>Active/1.0</branch>
+        <branch>KDE/4.10</branch>
+        <branch>KDE/4.11</branch>
+        <branch>KDE/4.12</branch>
+        <branch>KDE/4.13</branch>
+        <branch>KDE/4.8</branch>
+        <branch>KDE/4.9</branch>
+        <branch>davidedmundson/debug</branch>
+        <branch>ivan/combining-linked-and-used-resources</branch>
+        <branch>ivan/forgetting</branch>
+        <branch>ivan/libkactivities-experimental-stats</branch>
+        <branch>ivan/libkactivities-experimental-stats-resultmodel</branch>
+        <branch>ivan/libkactivities-stats</branch>
+        <branch>ivan/star-pattern</branch>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">KDE/4.13</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kxmlgui">
+      <name>KXMLGUI</name>
+      <description>KXMLGUI</description>
+      <icon/>
+      <path>frameworks/kxmlgui</path>
+      <web>https://cgit.kde.org/kxmlgui.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kxmlgui.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kxmlgui</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kxmlgui/kxmlgui-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kxmlgui</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kxmlgui</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kmediaplayer">
+      <name>KMediaPlayer</name>
+      <description>KMediaPlayer</description>
+      <icon/>
+      <path>frameworks/kmediaplayer</path>
+      <web>https://cgit.kde.org/kmediaplayer.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kmediaplayer.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kmediaplayer</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kmediaplayer/kmediaplayer-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kmediaplayer</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kmediaplayer</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kjs">
+      <name>KJS</name>
+      <description>KJS</description>
+      <icon/>
+      <path>frameworks/kjs</path>
+      <web>https://cgit.kde.org/kjs.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kjs.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kjs</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kjs/kjs-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kjs</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kjs</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kitemmodels">
+      <name>KItemModels</name>
+      <description>KItemModels</description>
+      <icon/>
+      <path>frameworks/kitemmodels</path>
+      <web>https://cgit.kde.org/kitemmodels.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kitemmodels.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kitemmodels</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kitemmodels/kitemmodels-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kitemmodels</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kitemmodels</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="attica">
+      <name>Attica</name>
+      <description>Attica is a Qt library that implements the Open Collaboration Services API.
+
+Mailing list: http://lists.freedesktop.org/mailman/listinfo/ocs
+Internet Relay Chat: #ocs@freenode</description>
+      <icon/>
+      <path>frameworks/attica</path>
+      <web>https://cgit.kde.org/attica.git</web>
+      <member username="gladhorn">Frederik Gladhorn</member>
+      <member username="mbatle">Mateu Batle</member>
+      <member username="whiting">Jeremy Whiting</member>
+      <member username="lpapp">Laszlo Papp</member>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/attica.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:attica</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/attica/attica-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/attica</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/attica</url>
+        <branch>cloud</branch>
+        <branch>gsoc2012-fxrh-jsonparser</branch>
+        <branch>master</branch>
+        <branch>qt4</branch>
+        <branch>qt5</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kdelibs4support">
+      <name>KDE4 Support</name>
+      <description>KDE 4 Support</description>
+      <icon/>
+      <path>frameworks/kdelibs4support</path>
+      <web>https://cgit.kde.org/kdelibs4support.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kdelibs4support.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kdelibs4support</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kdelibs4support/kdelibs4support-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kdelibs4support</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kdelibs4support</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="sonnet">
+      <name>Sonnet</name>
+      <description>Spelling framework for Qt.
+
+It has a plugin-based architecture, allowing it to use several different spell-checking libraries (the current supported ones are aspell, hspell and hunspell).
+
+It has automated language detection based on several heuristics (script used, trigram matching and language ranking on available languages in the spell-checking backend). This allows it to automatically switch language in a multi-language document.
+
+"Documentation":http://api.kde.org/frameworks-api/frameworks5-apidocs/sonnet/html/index.html</description>
+      <icon/>
+      <path>frameworks/sonnet</path>
+      <web>https://cgit.kde.org/sonnet.git</web>
+      <member username="sandsmark">Martin Tobias Holmedahl Sandsmark</member>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/sonnet.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:sonnet</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/sonnet/sonnet-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/sonnet</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/sonnet</url>
+        <branch>langdet</branch>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kwidgetsaddons">
+      <name>KWidgetsAddons</name>
+      <description>KWidgetsAddons</description>
+      <icon/>
+      <path>frameworks/kwidgetsaddons</path>
+      <web>https://cgit.kde.org/kwidgetsaddons.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kwidgetsaddons.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kwidgetsaddons</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kwidgetsaddons/kwidgetsaddons-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kwidgetsaddons</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kwidgetsaddons</url>
+        <branch>master</branch>
+        <branch>removeicon1</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="bluez-qt">
+      <name>BluezQt</name>
+      <description>Qt wrapper for Bluez 5 DBus API</description>
+      <icon/>
+      <path>frameworks/bluez-qt</path>
+      <web>https://cgit.kde.org/bluez-qt.git</web>
+      <member username="jriddell">Jonathan Riddell</member>
+      <member username="drosca">David Rosca</member>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/bluez-qt.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:bluez-qt</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/bluez-qt/bluez-qt-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/bluez-qt</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/bluez-qt</url>
+        <branch>Plasma/5.3</branch>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kfilemetadata">
+      <name>KFileMetaData</name>
+      <description>A library for extracting file metadata</description>
+      <icon/>
+      <path>frameworks/kfilemetadata</path>
+      <web>https://cgit.kde.org/kfilemetadata.git</web>
+      <member username="jriddell">Jonathan Riddell</member>
+      <member username="vhanda">Vishesh Handa</member>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kfilemetadata.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kfilemetadata</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kfilemetadata/kfilemetadata-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kfilemetadata</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kfilemetadata</url>
+        <branch>KDE/4.13</branch>
+        <branch>KDE/4.14</branch>
+        <branch>Plasma/5.0</branch>
+        <branch>Plasma/5.1</branch>
+        <branch>Plasma/5.2</branch>
+        <branch>Plasma/5.3</branch>
+        <branch>externalextractors</branch>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kapidox">
+      <name>Frameworks API Documentation Tools</name>
+      <description>Frameworks API Documentation Tools</description>
+      <icon/>
+      <path>frameworks/kapidox</path>
+      <web>https://cgit.kde.org/kapidox.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kapidox.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kapidox</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kapidox/kapidox-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kapidox</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kapidox</url>
+        <branch>fwinfo</branch>
+        <branch>master</branch>
+        <branch>olivier/generate_all_repos</branch>
+        <branch>olivier/refactoring</branch>
+        <branch>port_to_bootstrap</branch>
+        <branch>wip/kgenframeworksapidox-dot-dir</branch>
+        <branch>wip/standalone-depdiagram-prepare</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kauth">
+      <name>KAuth</name>
+      <description>KAuth</description>
+      <icon/>
+      <path>frameworks/kauth</path>
+      <web>https://cgit.kde.org/kauth.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kauth.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kauth</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kauth/kauth-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kauth</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kauth</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kio">
+      <name>KIO</name>
+      <description>KIO</description>
+      <icon/>
+      <path>frameworks/kio</path>
+      <web>https://cgit.kde.org/kio.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kio.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kio</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kio/kio-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kio</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kio</url>
+        <branch>aseigo/cleanups</branch>
+        <branch>dirlister-baloosearch</branch>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="ki18n">
+      <name>Ki18n</name>
+      <description>Ki18n</description>
+      <icon/>
+      <path>frameworks/ki18n</path>
+      <web>https://cgit.kde.org/ki18n.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/ki18n.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:ki18n</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/ki18n/ki18n-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/ki18n</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/ki18n</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kwindowsystem">
+      <name>KWindowSystem</name>
+      <description>KWindowSystem</description>
+      <icon/>
+      <path>frameworks/kwindowsystem</path>
+      <web>https://cgit.kde.org/kwindowsystem.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kwindowsystem.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kwindowsystem</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kwindowsystem/kwindowsystem-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kwindowsystem</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kwindowsystem</url>
+        <branch>mart/kwin/backgroundContrast2</branch>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="threadweaver">
+      <name>ThreadWeaver</name>
+      <description>ThreadWeaver</description>
+      <icon/>
+      <path>frameworks/threadweaver</path>
+      <web>https://cgit.kde.org/threadweaver.git</web>
+      <member username="mirko">Mirko Boehm</member>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/threadweaver.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:threadweaver</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/threadweaver/threadweaver-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/threadweaver</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/threadweaver</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kxmlrpcclient">
+      <name>kxmlrpcclient</name>
+      <description></description>
+      <icon/>
+      <path>frameworks/kxmlrpcclient</path>
+      <web>https://cgit.kde.org/kxmlrpcclient.git</web>
+      <member username="dvratil">Dan Vrátil</member>
+      <member username="apol">Aleix Pol Gonzalez</member>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kxmlrpcclient.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kxmlrpcclient</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kxmlrpcclient/kxmlrpcclient-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kxmlrpcclient</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kxmlrpcclient</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="baloo">
+      <name>Baloo</name>
+      <description>Baloo is a framework for searching and managing metadata.</description>
+      <icon/>
+      <path>frameworks/baloo</path>
+      <web>https://cgit.kde.org/baloo.git</web>
+      <member username="vhanda">Vishesh Handa</member>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/baloo.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:baloo</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/baloo/baloo-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/baloo</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/baloo</url>
+        <branch>KDE/4.14</branch>
+        <branch>extractor_protocol</branch>
+        <branch>fileTime_tBug</branch>
+        <branch>lucene</branch>
+        <branch>master</branch>
+        <branch>pinak/monitorListView</branch>
+        <branch>positionDB</branch>
+        <branch>vendor/intevation/4.14</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kdbusaddons">
+      <name>KDBusAddons</name>
+      <description>KDBusAddons</description>
+      <icon/>
+      <path>frameworks/kdbusaddons</path>
+      <web>https://cgit.kde.org/kdbusaddons.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kdbusaddons.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kdbusaddons</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kdbusaddons/kdbusaddons-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kdbusaddons</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kdbusaddons</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kimageformats">
+      <name>KImageFormats</name>
+      <description>KImageFormats</description>
+      <icon/>
+      <path>frameworks/kimageformats</path>
+      <web>https://cgit.kde.org/kimageformats.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kimageformats.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kimageformats</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kimageformats/kimageformats-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kimageformats</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kimageformats</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kbookmarks">
+      <name>KBookmarks</name>
+      <description>KBookmarks</description>
+      <icon/>
+      <path>frameworks/kbookmarks</path>
+      <web>https://cgit.kde.org/kbookmarks.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kbookmarks.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kbookmarks</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kbookmarks/kbookmarks-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kbookmarks</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kbookmarks</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kwallet">
+      <name>KWallet Framework</name>
+      <description></description>
+      <icon/>
+      <path>frameworks/kwallet</path>
+      <web>https://cgit.kde.org/kwallet.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kwallet.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kwallet</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kwallet/kwallet-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kwallet</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kwallet</url>
+        <branch>kwalletd4_dbus_compat</branch>
+        <branch>master</branch>
+        <branch>pam</branch>
+        <branch>pamAutotests</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kparts">
+      <name>KParts</name>
+      <description>KParts</description>
+      <icon/>
+      <path>frameworks/kparts</path>
+      <web>https://cgit.kde.org/kparts.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kparts.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kparts</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kparts/kparts-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kparts</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kparts</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kemoticons">
+      <name>KEmoticons</name>
+      <description>KEmoticons</description>
+      <icon/>
+      <path>frameworks/kemoticons</path>
+      <web>https://cgit.kde.org/kemoticons.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kemoticons.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kemoticons</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kemoticons/kemoticons-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kemoticons</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kemoticons</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="solid">
+      <name>Solid</name>
+      <description>Solid</description>
+      <icon/>
+      <path>frameworks/solid</path>
+      <web>https://cgit.kde.org/solid.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/solid.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:solid</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/solid/solid-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/solid</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/solid</url>
+        <branch>apiCleaning</branch>
+        <branch>broulik/kdeconnect-backend</branch>
+        <branch>broulik/modelimport</branch>
+        <branch>forAleixWithLove</branch>
+        <branch>master</branch>
+        <branch>newPowerApi</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="knewstuff">
+      <name>KNewStuff</name>
+      <description>KNewStuff</description>
+      <icon/>
+      <path>frameworks/knewstuff</path>
+      <web>https://cgit.kde.org/knewstuff.git</web>
+      <member username="whiting">Jeremy Whiting</member>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/knewstuff.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:knewstuff</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/knewstuff/knewstuff-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/knewstuff</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/knewstuff</url>
+        <branch>master</branch>
+        <branch>ui-business-split</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kdesu">
+      <name>KDE Su</name>
+      <description>KDE Su</description>
+      <icon/>
+      <path>frameworks/kdesu</path>
+      <web>https://cgit.kde.org/kdesu.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kdesu.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kdesu</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kdesu/kdesu-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kdesu</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kdesu</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kactivities-stats">
+      <name>Activities Statistics Library</name>
+      <description>A library for accessing the usage data collected by the activities system.</description>
+      <icon>preferences-activities</icon>
+      <path>frameworks/kactivities-stats</path>
+      <web>https://cgit.kde.org/kactivities-stats.git</web>
+      <member username="ivan">Ivan Čukić</member>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kactivities-stats.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kactivities-stats</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kactivities-stats/kactivities-stats-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kactivities-stats</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kactivities-stats</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kcrash">
+      <name>KCrash</name>
+      <description>KCrash</description>
+      <icon/>
+      <path>frameworks/kcrash</path>
+      <web>https://cgit.kde.org/kcrash.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kcrash.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kcrash</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kcrash/kcrash-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kcrash</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kcrash</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="oxygen-icons5">
+      <name>Oxygen Icons</name>
+      <description>Oxygen icon theme</description>
+      <icon/>
+      <path>frameworks/oxygen-icons5</path>
+      <web>https://cgit.kde.org/oxygen-icons5.git</web>
+      <member username="jriddell">Jonathan Riddell</member>
+      <member username="andreask">andreas kainz</member>
+      <member username="sitter">Harald Sitter</member>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/oxygen-icons5.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:oxygen-icons5</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/oxygen-icons5/oxygen-icons5-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/oxygen-icons5</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/oxygen-icons5</url>
+        <branch>master</branch>
+        <branch>qt4</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kitemviews">
+      <name>KItemViews</name>
+      <description>KItemViews</description>
+      <icon/>
+      <path>frameworks/kitemviews</path>
+      <web>https://cgit.kde.org/kitemviews.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kitemviews.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kitemviews</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kitemviews/kitemviews-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kitemviews</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kitemviews</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kconfigwidgets">
+      <name>KConfigWidgets</name>
+      <description>Widgets for KConfig</description>
+      <icon/>
+      <path>frameworks/kconfigwidgets</path>
+      <web>https://cgit.kde.org/kconfigwidgets.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kconfigwidgets.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kconfigwidgets</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kconfigwidgets/kconfigwidgets-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kconfigwidgets</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kconfigwidgets</url>
+        <branch>mart/mart/qmlKcmsPureQObject</branch>
+        <branch>mart/qmlKcms</branch>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="khtml">
+      <name>KHtml</name>
+      <description>KHtml</description>
+      <icon/>
+      <path>frameworks/khtml</path>
+      <web>https://cgit.kde.org/khtml.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/khtml.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:khtml</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/khtml/khtml-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/khtml</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/khtml</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="ktextwidgets">
+      <name>KTextWidgets</name>
+      <description>KTextWidgets</description>
+      <icon/>
+      <path>frameworks/ktextwidgets</path>
+      <web>https://cgit.kde.org/ktextwidgets.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/ktextwidgets.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:ktextwidgets</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/ktextwidgets/ktextwidgets-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/ktextwidgets</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/ktextwidgets</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kconfig">
+      <name>KConfig</name>
+      <description>KConfig</description>
+      <icon/>
+      <path>frameworks/kconfig</path>
+      <web>https://cgit.kde.org/kconfig.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kconfig.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kconfig</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kconfig/kconfig-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kconfig</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kconfig</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kguiaddons">
+      <name>KGuiAddons</name>
+      <description>KGuiAddons</description>
+      <icon/>
+      <path>frameworks/kguiaddons</path>
+      <web>https://cgit.kde.org/kguiaddons.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kguiaddons.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kguiaddons</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kguiaddons/kguiaddons-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kguiaddons</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kguiaddons</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="knotifyconfig">
+      <name>KNotifyConfig</name>
+      <description>KNotifyConfig</description>
+      <icon/>
+      <path>frameworks/knotifyconfig</path>
+      <web>https://cgit.kde.org/knotifyconfig.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/knotifyconfig.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:knotifyconfig</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/knotifyconfig/knotifyconfig-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/knotifyconfig</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/knotifyconfig</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="karchive">
+      <name>KArchive</name>
+      <description>Qt 5 addon providing access to numerous types of archives</description>
+      <icon/>
+      <path>frameworks/karchive</path>
+      <web>https://cgit.kde.org/karchive.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/karchive.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:karchive</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/karchive/karchive-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/karchive</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/karchive</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kded">
+      <name>KDE Daemon</name>
+      <description>KDE Daemon</description>
+      <icon/>
+      <path>frameworks/kded</path>
+      <web>https://cgit.kde.org/kded.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kded.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kded</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kded/kded-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kded</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kded</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="modemmanager-qt">
+      <name>ModemManagerQt</name>
+      <description>Qt wrapper for ModemManager DBus API.
+
+Report bugs in bugs.kde.org, under product frameworks-modemmanager-qt.</description>
+      <icon/>
+      <path>frameworks/modemmanager-qt</path>
+      <web>https://cgit.kde.org/modemmanager-qt.git</web>
+      <member username="lvsouza">Lamarque Souza</member>
+      <member username="iliakats">Ilia Kats</member>
+      <member username="wstephens">Will Stephenson</member>
+      <member username="jriddell">Jonathan Riddell</member>
+      <member username="grulich">Jan Grulich</member>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/modemmanager-qt.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:modemmanager-qt</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/modemmanager-qt/modemmanager-qt-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/modemmanager-qt</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/modemmanager-qt</url>
+        <branch>MM/0.5</branch>
+        <branch>MM/0.6</branch>
+        <branch>MM/1.0</branch>
+        <branch>Plasma/5.0</branch>
+        <branch>Plasma/5.1</branch>
+        <branch>Plasma/5.2</branch>
+        <branch>danttiIpConfig</branch>
+        <branch>frameworks</branch>
+        <branch>kamath</branch>
+        <branch>master</branch>
+        <branch>mm08</branch>
+        <branch>mm_0_6_branch</branch>
+        <branch>qt5</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">MM/1.0</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kunitconversion">
+      <name>KUnitConversion</name>
+      <description>KUnitConversion</description>
+      <icon/>
+      <path>frameworks/kunitconversion</path>
+      <web>https://cgit.kde.org/kunitconversion.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kunitconversion.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kunitconversion</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kunitconversion/kunitconversion-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kunitconversion</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kunitconversion</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kinit">
+      <name>KInit</name>
+      <description>KInit</description>
+      <icon/>
+      <path>frameworks/kinit</path>
+      <web>https://cgit.kde.org/kinit.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kinit.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kinit</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kinit/kinit-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kinit</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kinit</url>
+        <branch>master</branch>
+        <branch>prevent-environment-problems</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="krunner">
+      <name>KRunner</name>
+      <description>Framework for providing different actions given a string query.</description>
+      <icon/>
+      <path>frameworks/krunner</path>
+      <web>https://cgit.kde.org/krunner.git</web>
+      <member username="vhanda">Vishesh Handa</member>
+      <member username="apol">Aleix Pol Gonzalez</member>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/krunner.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:krunner</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/krunner/krunner-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/krunner</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/krunner</url>
+        <branch>master</branch>
+        <branch>work/mirko-fix-assert-krunner</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kross">
+      <name>Kross</name>
+      <description>Kross</description>
+      <icon/>
+      <path>frameworks/kross</path>
+      <web>https://cgit.kde.org/kross.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kross.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kross</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kross/kross-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kross</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kross</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="plasma-framework">
+      <name>KDE Plasma Framework</name>
+      <description>Plasma library and runtime components based upon KF5 and Qt5</description>
+      <icon/>
+      <path>frameworks/plasma-framework</path>
+      <web>https://cgit.kde.org/plasma-framework.git</web>
+      <member username="ivan">Ivan Čukić</member>
+      <member username="mart">Marco Martin</member>
+      <member username="aseigo">Aaron J. Seigo</member>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/plasma-framework.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:plasma-framework</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/plasma-framework/plasma-framework-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/plasma-framework</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/plasma-framework</url>
+        <branch>PlasmaTypesClass</branch>
+        <branch>asyncServicePreparation</branch>
+        <branch>breeze/5.5</branch>
+        <branch>bshah/meter-qml</branch>
+        <branch>bshah/plotter-qml</branch>
+        <branch>bshah/shaderitem</branch>
+        <branch>cmake-config</branch>
+        <branch>davidedmundson/containmentcleanup</branch>
+        <branch>davidedmundson/containmentcleanup2</branch>
+        <branch>davidedmundson/keyboard_shortcuts</branch>
+        <branch>davidedmundson/kquickcontrols</branch>
+        <branch>davidedmundson/native_render_frames</branch>
+        <branch>fancyCalendar</branch>
+        <branch>interactiveconsole_in_shellpackage</branch>
+        <branch>ivan/platform-change-splash</branch>
+        <branch>ivan/platform-clients</branch>
+        <branch>ivan/shell-switching</branch>
+        <branch>ivan/shell-switching-2</branch>
+        <branch>kcmConfigPages</branch>
+        <branch>mart/AssociatedApplicationFromMime</branch>
+        <branch>mart/DialogBackgroundHints</branch>
+        <branch>mart/KPackage</branch>
+        <branch>mart/KPart</branch>
+        <branch>mart/QtControlsCheckBox</branch>
+        <branch>mart/QtControlsSlider</branch>
+        <branch>mart/SvgDevicePixelRatio</branch>
+        <branch>mart/XPlasmaRootPath</branch>
+        <branch>mart/alternativesConfig</branch>
+        <branch>mart/basicDeleteUndo</branch>
+        <branch>mart/completeQtQuickStyle</branch>
+        <branch>mart/coronaautotest</branch>
+        <branch>mart/customShell</branch>
+        <branch>mart/customTooltipDialog</branch>
+        <branch>mart/differentControlThemes</branch>
+        <branch>mart/framesvg_native2</branch>
+        <branch>mart/inlineEditMenu</branch>
+        <branch>mart/interactiveconsole</branch>
+        <branch>mart/kdeclarativeNamespace</branch>
+        <branch>mart/negativePositiveColors</branch>
+        <branch>mart/packageFallback</branch>
+        <branch>mart/plasmaquickNamespace</branch>
+        <branch>mart/plasmasvgicons</branch>
+        <branch>mart/plasmoidMove</branch>
+        <branch>mart/plasmoidVisualMargins</branch>
+        <branch>mart/plotter</branch>
+        <branch>mart/popupAppletEventFilter</branch>
+        <branch>mart/privatepackageloader</branch>
+        <branch>mart/qqc2style</branch>
+        <branch>mart/singleQmlEngineExperiment</branch>
+        <branch>mart/svg/stylecolors</branch>
+        <branch>mart/sycocacleanup</branch>
+        <branch>mart/waylandDialog</branch>
+        <branch>master</branch>
+        <branch>mklapetek/notifications-next</branch>
+        <branch>native_rendering</branch>
+        <branch>no_initial_shadows</branch>
+        <branch>plasmaview</branch>
+        <branch>sebas/devguide</branch>
+        <branch>sebas/dpi</branch>
+        <branch>sebas/pluginloader</branch>
+        <branch>sebas/plugintrader</branch>
+        <branch>terietor/plasmaview</branch>
+        <branch>terietor/split-view</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kiconthemes">
+      <name>KIconThemes</name>
+      <description>KIconThemes</description>
+      <icon/>
+      <path>frameworks/kiconthemes</path>
+      <web>https://cgit.kde.org/kiconthemes.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kiconthemes.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kiconthemes</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kiconthemes/kiconthemes-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kiconthemes</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kiconthemes</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="syntax-highlighting">
+      <name>Syntax Highlighting Engine</name>
+      <description>Syntax highlighting Engine for Structured Text and Code.</description>
+      <icon/>
+      <path>frameworks/syntax-highlighting</path>
+      <web>https://cgit.kde.org/syntax-highlighting.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/syntax-highlighting.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:syntax-highlighting</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/syntax-highlighting/syntax-highlighting-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/syntax-highlighting</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/syntax-highlighting</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kglobalaccel">
+      <name>KGlobalAccel</name>
+      <description>KGlobalAccel</description>
+      <icon/>
+      <path>frameworks/kglobalaccel</path>
+      <web>https://cgit.kde.org/kglobalaccel.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kglobalaccel.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kglobalaccel</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kglobalaccel/kglobalaccel-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kglobalaccel</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kglobalaccel</url>
+        <branch>kglobalaccel-master</branch>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kdesignerplugin">
+      <name>KDesignerPlugin</name>
+      <description>KDesignerPlugin</description>
+      <icon/>
+      <path>frameworks/kdesignerplugin</path>
+      <web>https://cgit.kde.org/kdesignerplugin.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kdesignerplugin.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kdesignerplugin</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kdesignerplugin/kdesignerplugin-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kdesignerplugin</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kdesignerplugin</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kdnssd">
+      <name>KDNSSD Framework</name>
+      <description>KDNSSD Framework</description>
+      <icon/>
+      <path>frameworks/kdnssd</path>
+      <web>https://cgit.kde.org/kdnssd.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kdnssd.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kdnssd</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kdnssd/kdnssd-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kdnssd</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kdnssd</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kidletime">
+      <name>KIdleTime</name>
+      <description>KIdleTime</description>
+      <icon/>
+      <path>frameworks/kidletime</path>
+      <web>https://cgit.kde.org/kidletime.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kidletime.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kidletime</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kidletime/kidletime-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kidletime</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kidletime</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="ktexteditor">
+      <name>KTextEditor</name>
+      <description>KTextEditor Framework</description>
+      <icon/>
+      <path>frameworks/ktexteditor</path>
+      <web>https://cgit.kde.org/ktexteditor.git</web>
+      <member username="cullmann">Christoph Cullmann</member>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/ktexteditor.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:ktexteditor</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/ktexteditor/ktexteditor-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/ktexteditor</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/ktexteditor</url>
+        <branch>master</branch>
+        <branch>msvc2010</branch>
+        <branch>msvc2012</branch>
+        <branch>multicursor</branch>
+        <branch>vimode-FT-exclusive</branch>
+        <branch>vimode-consume-search</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="networkmanager-qt">
+      <name>NetworkManagerQt</name>
+      <description>Qt wrapper for NetworkManager API.
+
+Report bugs in bugs.kde.org, under product frameworks-networkmanager-qt.</description>
+      <icon/>
+      <path>frameworks/networkmanager-qt</path>
+      <web>https://cgit.kde.org/networkmanager-qt.git</web>
+      <member username="lvsouza">Lamarque Souza</member>
+      <member username="iliakats">Ilia Kats</member>
+      <member username="wstephens">Will Stephenson</member>
+      <member username="jriddell">Jonathan Riddell</member>
+      <member username="grulich">Jan Grulich</member>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/networkmanager-qt.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:networkmanager-qt</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/networkmanager-qt/networkmanager-qt-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/networkmanager-qt</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/networkmanager-qt</url>
+        <branch>8021x-certkeyschmeme-attempt</branch>
+        <branch>8021x-make-pki-cool</branch>
+        <branch>NM/0.9</branch>
+        <branch>NM/0.9.8</branch>
+        <branch>Plasma/5.0</branch>
+        <branch>Plasma/5.1</branch>
+        <branch>dantti-simplePtr</branch>
+        <branch>danttiIpConfig</branch>
+        <branch>delete</branch>
+        <branch>doc</branch>
+        <branch>framework</branch>
+        <branch>master</branch>
+        <branch>nm_0_9_6_branch</branch>
+        <branch>qt5</branch>
+        <branch>settings</branch>
+        <branch>unit-tests</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">NM/0.9.8</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kpeople">
+      <name>KPeople</name>
+      <description>A library that provides access to all contacts and the people who hold them</description>
+      <icon/>
+      <path>frameworks/kpeople</path>
+      <web>https://cgit.kde.org/kpeople.git</web>
+      <member username="davidedmundson">David Edmundson</member>
+      <member username="mklapetek">Martin Klapetek</member>
+      <member username="apol">Aleix Pol Gonzalez</member>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kpeople.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kpeople</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kpeople/kpeople-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kpeople</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kpeople</url>
+        <branch>actions_plugin</branch>
+        <branch>apol/queries</branch>
+        <branch>cleanup</branch>
+        <branch>customContact</branch>
+        <branch>dave</branch>
+        <branch>gitlog</branch>
+        <branch>gsoc14</branch>
+        <branch>kpeople2</branch>
+        <branch>lazy_query</branch>
+        <branch>libkpeople-0.1</branch>
+        <branch>libkpeople-0.2</branch>
+        <branch>libkpeople-0.3</branch>
+        <branch>lookupService</branch>
+        <branch>master</branch>
+        <branch>mklapetek/refactor</branch>
+        <branch>mklapetek/toplevel_contacts</branch>
+        <branch>model_tests</branch>
+        <branch>person_manager_tests</branch>
+        <branch>person_update_tests</branch>
+        <branch>recent_emails2</branch>
+        <branch>soo_much_faster</branch>
+        <branch>superhugechanges</branch>
+        <branch>unit_tests</branch>
+        <branch>verbose</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">libkpeople-0.3</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kdewebkit">
+      <name>KDE Webkit</name>
+      <description>KDE Webkit</description>
+      <icon/>
+      <path>frameworks/kdewebkit</path>
+      <web>https://cgit.kde.org/kdewebkit.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kdewebkit.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kdewebkit</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kdewebkit/kdewebkit-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kdewebkit</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kdewebkit</url>
+        <branch>kdewebengine</branch>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kcodecs">
+      <name>KCodecs</name>
+      <description>KCodecs provide a collection of methods to manipulate strings using various encodings</description>
+      <icon/>
+      <path>frameworks/kcodecs</path>
+      <web>https://cgit.kde.org/kcodecs.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kcodecs.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kcodecs</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kcodecs/kcodecs-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kcodecs</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kcodecs</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kjsembed">
+      <name>KJSEmbed</name>
+      <description>KJSEmbed</description>
+      <icon/>
+      <path>frameworks/kjsembed</path>
+      <web>https://cgit.kde.org/kjsembed.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kjsembed.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kjsembed</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kjsembed/kjsembed-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kjsembed</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kjsembed</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="knotifications">
+      <name>KNotifications</name>
+      <description>KNotifications</description>
+      <icon/>
+      <path>frameworks/knotifications</path>
+      <web>https://cgit.kde.org/knotifications.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/knotifications.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:knotifications</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/knotifications/knotifications-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/knotifications</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/knotifications</url>
+        <branch>master</branch>
+        <branch>mklapetek/knotify-merge</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kcompletion">
+      <name>KCompletion</name>
+      <description>KCompletion</description>
+      <icon/>
+      <path>frameworks/kcompletion</path>
+      <web>https://cgit.kde.org/kcompletion.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kcompletion.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kcompletion</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kcompletion/kcompletion-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kcompletion</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kcompletion</url>
+        <branch>clean_up_private_slots</branch>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="breeze-icons">
+      <name>Breeze Icons</name>
+      <description>Breeze icon theme.</description>
+      <icon/>
+      <path>frameworks/breeze-icons</path>
+      <web>https://cgit.kde.org/breeze-icons.git</web>
+      <member username="dfaure">David Faure</member>
+      <member username="sitter">Harald Sitter</member>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/breeze-icons.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:breeze-icons</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/breeze-icons/breeze-icons-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/breeze-icons</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/breeze-icons</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="frameworkintegration">
+      <name>Integration for Frameworks</name>
+      <description>Framework providing components to allow applications to integrate with a KDE Workspace</description>
+      <icon/>
+      <path>frameworks/frameworkintegration</path>
+      <web>https://cgit.kde.org/frameworkintegration.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/frameworkintegration.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:frameworkintegration</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/frameworkintegration/frameworkintegration-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/frameworkintegration</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/frameworkintegration</url>
+        <branch>mart/useLookAndFeel</branch>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kpty">
+      <name>KPty</name>
+      <description>KPty</description>
+      <icon/>
+      <path>frameworks/kpty</path>
+      <web>https://cgit.kde.org/kpty.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kpty.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kpty</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kpty/kpty-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kpty</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kpty</url>
+        <branch>master</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kservice">
+      <name>KService</name>
+      <description>KService</description>
+      <icon/>
+      <path>frameworks/kservice</path>
+      <web>https://cgit.kde.org/kservice.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kservice.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kservice</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kservice/kservice-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kservice</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kservice</url>
+        <branch>dfaure/desktop-file-index</branch>
+        <branch>fix_path</branch>
+        <branch>master</branch>
+        <branch>sebas/kpluginindex</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+    <project identifier="kcoreaddons">
+      <name>KCoreAddons</name>
+      <description>KCoreAddons</description>
+      <icon/>
+      <path>frameworks/kcoreaddons</path>
+      <web>https://cgit.kde.org/kcoreaddons.git</web>
+      <repo>
+        <active>true</active>
+        <web type="gitweb">https://cgit.kde.org/kcoreaddons.git</web>
+        <url protocol="ssh" access="read+write">git@git.kde.org:kcoreaddons</url>
+        <url protocol="tarball" access="read-only">http://anongit.kde.org/kcoreaddons/kcoreaddons-latest.tar.gz</url>
+        <url protocol="git" access="read-only">git://anongit.kde.org/kcoreaddons</url>
+        <url protocol="http" access="read-only">http://anongit.kde.org/kcoreaddons</url>
+        <branch>master</branch>
+        <branch>sebas/kpluginindex</branch>
+        <branch>sebas/kpluginindex2</branch>
+        <branch>sebas/kpluginmetadata</branch>
+        <branch i18n="trunk">none</branch>
+        <branch i18n="stable">none</branch>
+        <branch i18n="trunk_kf5">master</branch>
+        <branch i18n="stable_kf5">none</branch>
+      </repo>
+    </project>
+  </component>
+  <component identifier="kde">
+    <name>KDE</name>
+    <description></description>
+    <icon/>
+    <path>kde</path>
+    <web/>
+    <module identifier="applications">
+      <name>KDE Applications</name>
+      <description></description>
+      <icon/>
+      <path>kde/applications</path>
+      <web/>
+      <project identifier="dolphin">
+        <name>Dolphin</name>
+        <description>KDE File Manager</description>
+        <icon/>
+        <path>kde/applications/dolphin</path>
+        <web>https://cgit.kde.org/dolphin.git</web>
+        <member username="freininghaus">Frank Reininghaus</member>
+        <member username="emmanuelp">Emmanuel Pescosta</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/dolphin.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:dolphin</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/dolphin/dolphin-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/dolphin</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/dolphin</url>
+          <branch>Applications/14.12</branch>
+          <branch>Applications/15.08</branch>
+          <branch>Applications/15.12</branch>
+          <branch>Applications/16.04</branch>
+          <branch>Applications/16.08</branch>
+          <branch>Applications/16.12</branch>
+          <branch>KDE/4.0</branch>
+          <branch>KDE/4.1</branch>
+          <branch>KDE/4.10</branch>
+          <branch>KDE/4.11</branch>
+          <branch>KDE/4.12</branch>
+          <branch>KDE/4.13</branch>
+          <branch>KDE/4.14</branch>
+          <branch>KDE/4.2</branch>
+          <branch>KDE/4.3</branch>
+          <branch>KDE/4.4</branch>
+          <branch>KDE/4.5</branch>
+          <branch>KDE/4.6</branch>
+          <branch>KDE/4.7</branch>
+          <branch>KDE/4.8</branch>
+          <branch>KDE/4.9</branch>
+          <branch>davidedmundson/highdpi</branch>
+          <branch>emmanuelp/tabhandling</branch>
+          <branch>feature/baloo</branch>
+          <branch>focus</branch>
+          <branch>fvport</branch>
+          <branch>gsoc/arnavdhamija/2016</branch>
+          <branch>isemenov/qml</branch>
+          <branch>kdepim/enterprise-4.0.83</branch>
+          <branch>kdepim/enterprise-4.1</branch>
+          <branch>master</branch>
+          <branch>origin</branch>
+          <branch>plasma/isemenov/fvport</branch>
+          <branch>plasma/isemenov/qml</branch>
+          <branch>plasma/sebas/dirlister</branch>
+          <branch>stashAction</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Applications/16.12</branch>
+        </repo>
+      </project>
+      <project identifier="kfind">
+        <name>KFind</name>
+        <description>KDE file find utility</description>
+        <icon/>
+        <path>kde/applications/kfind</path>
+        <web>https://cgit.kde.org/kfind.git</web>
+        <member username="broulik">Kai-Uwe Broulik</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/kfind.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:kfind</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/kfind/kfind-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/kfind</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/kfind</url>
+          <branch>Applications/16.12</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Applications/16.12</branch>
+        </repo>
+      </project>
+      <project identifier="konqueror">
+        <name>Konqueror</name>
+        <description>Konqueror</description>
+        <icon/>
+        <path>kde/applications/konqueror</path>
+        <web>https://cgit.kde.org/konqueror.git</web>
+        <member username="dfaure">David Faure</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/konqueror.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:konqueror</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/konqueror/konqueror-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/konqueror</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/konqueror</url>
+          <branch>Applications/16.12</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Applications/16.12</branch>
+        </repo>
+      </project>
+      <project identifier="konsole">
+        <name>Konsole</name>
+        <description>KDE's terminal emulator.</description>
+        <icon/>
+        <path>kde/applications/konsole</path>
+        <web>https://cgit.kde.org/konsole.git</web>
+        <member username="mueller">Dirk Mueller</member>
+        <member username="aacid">Albert Astals Cid</member>
+        <member username="ianmonroe">Ian Monroe</member>
+        <member username="freininghaus">Frank Reininghaus</member>
+        <member username="ppenz">Peter Penz</member>
+        <member username="hindenburg">Kurt Hindenburg</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/konsole.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:konsole</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/konsole/konsole-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/konsole</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/konsole</url>
+          <branch>Applications/14.12</branch>
+          <branch>Applications/15.04</branch>
+          <branch>Applications/15.08</branch>
+          <branch>Applications/15.12</branch>
+          <branch>Applications/16.04</branch>
+          <branch>Applications/16.08</branch>
+          <branch>Applications/16.12</branch>
+          <branch>KDE/1.1</branch>
+          <branch>KDE/2.0</branch>
+          <branch>KDE/2.1</branch>
+          <branch>KDE/2.2</branch>
+          <branch>KDE/3.0</branch>
+          <branch>KDE/3.1</branch>
+          <branch>KDE/3.2</branch>
+          <branch>KDE/3.3</branch>
+          <branch>KDE/3.4</branch>
+          <branch>KDE/3.5</branch>
+          <branch>KDE/4.0</branch>
+          <branch>KDE/4.1</branch>
+          <branch>KDE/4.10</branch>
+          <branch>KDE/4.11</branch>
+          <branch>KDE/4.12</branch>
+          <branch>KDE/4.13</branch>
+          <branch>KDE/4.14</branch>
+          <branch>KDE/4.2</branch>
+          <branch>KDE/4.3</branch>
+          <branch>KDE/4.4</branch>
+          <branch>KDE/4.5</branch>
+          <branch>KDE/4.6</branch>
+          <branch>KDE/4.7</branch>
+          <branch>KDE/4.8</branch>
+          <branch>KDE/4.9</branch>
+          <branch>KDE/trunk_oct06may07</branch>
+          <branch>adaptee/ssh-parse-refactor</branch>
+          <branch>config_dialog</branch>
+          <branch>focus</branch>
+          <branch>history-rework</branch>
+          <branch>konsole-settings</branch>
+          <branch>konsole-settings-v2</branch>
+          <branch>master</branch>
+          <branch>remove-KUniqueApplication</branch>
+          <branch>sengels/winport</branch>
+          <branch>settings_dialog</branch>
+          <branch>winport</branch>
+          <branch>winport-frameworks</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Applications/16.12</branch>
+        </repo>
+      </project>
+      <project identifier="khelpcenter">
+        <name>KHelpCenter</name>
+        <description>Application to show programs documentation</description>
+        <icon/>
+        <path>kde/applications/khelpcenter</path>
+        <web>https://cgit.kde.org/khelpcenter.git</web>
+        <member username="ltoscano">Luigi Toscano</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/khelpcenter.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:khelpcenter</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/khelpcenter/khelpcenter-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/khelpcenter</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/khelpcenter</url>
+          <branch>Applications/16.04</branch>
+          <branch>Applications/16.08</branch>
+          <branch>Applications/16.12</branch>
+          <branch>Plasma/5.0</branch>
+          <branch>Plasma/5.1</branch>
+          <branch>Plasma/5.2</branch>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Applications/16.12</branch>
+        </repo>
+      </project>
+      <project identifier="keditbookmarks">
+        <name>KEditBookmarks</name>
+        <description>Bookmarks editor</description>
+        <icon/>
+        <path>kde/applications/keditbookmarks</path>
+        <web>https://cgit.kde.org/keditbookmarks.git</web>
+        <member username="dfaure">David Faure</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/keditbookmarks.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:keditbookmarks</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/keditbookmarks/keditbookmarks-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/keditbookmarks</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/keditbookmarks</url>
+          <branch>Applications/16.12</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Applications/16.12</branch>
+        </repo>
+      </project>
+      <project identifier="kdialog">
+        <name>KDialog</name>
+        <description>KDialog can be used to show nice dialog boxes from shell scripts</description>
+        <icon/>
+        <path>kde/applications/kdialog</path>
+        <web>https://cgit.kde.org/kdialog.git</web>
+        <member username="dfaure">David Faure</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/kdialog.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:kdialog</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/kdialog/kdialog-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/kdialog</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/kdialog</url>
+          <branch>Applications/16.12</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Applications/16.12</branch>
+        </repo>
+      </project>
+      <project identifier="kate">
+        <name>Kate</name>
+        <description>An advanced editor component which is used in numerous KDE applications requiring a text editing component
+
+The Kate project develops two main products: KatePart, the advanced editor component which is used in numerous KDE applications requiring a text editing component, and Kate, a MDI text editor application. In addition, we provide KWrite, a simple SDI editor shell which allows the user to select his/her favourite editor component.</description>
+        <icon/>
+        <path>kde/applications/kate</path>
+        <web>https://cgit.kde.org/kate.git</web>
+        <member username="cullmann">Christoph Cullmann</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/kate.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:kate</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/kate/kate-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/kate</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/kate</url>
+          <branch>Applications/14.12</branch>
+          <branch>Applications/15.04</branch>
+          <branch>Applications/15.08</branch>
+          <branch>Applications/15.12</branch>
+          <branch>Applications/16.04</branch>
+          <branch>Applications/16.08</branch>
+          <branch>Applications/16.12</branch>
+          <branch>KDE/4.10</branch>
+          <branch>KDE/4.11</branch>
+          <branch>KDE/4.12</branch>
+          <branch>KDE/4.13</branch>
+          <branch>KDE/4.14</branch>
+          <branch>KDE/4.7</branch>
+          <branch>KDE/4.8</branch>
+          <branch>KDE/4.9</branch>
+          <branch>goinnn-kate-plugins</branch>
+          <branch>kfunk/fix-katecompletionmodel</branch>
+          <branch>master</branch>
+          <branch>plasma/sreich/declarative-kate-applet</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Applications/16.12</branch>
+        </repo>
+      </project>
+    </module>
+    <module identifier="workspace">
+      <name>Workspace</name>
+      <description></description>
+      <icon/>
+      <path>kde/workspace</path>
+      <web/>
+      <project identifier="discover">
+        <name>Discover</name>
+        <description>KDE and Plasma resources management GUI</description>
+        <icon>muondiscover</icon>
+        <path>kde/workspace/discover</path>
+        <web>https://cgit.kde.org/discover.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="apol">Aleix Pol Gonzalez</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/discover.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:discover</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/discover/discover-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/discover</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/discover</url>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>apol/kns-sources-backend</branch>
+          <branch>appstream-addons</branch>
+          <branch>flatpak-backend</branch>
+          <branch>kirigami</branch>
+          <branch>master</branch>
+          <branch>qapt+appstream</branch>
+          <branch>snap-backend</branch>
+          <branch>upstreamCategories</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="plasma-pa">
+        <name>Plasma Applet for Audio Volume</name>
+        <description>Plasma applet for audio volume management using PulseAudio</description>
+        <icon/>
+        <path>kde/workspace/plasma-pa</path>
+        <web>https://cgit.kde.org/plasma-pa.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="sitter">Harald Sitter</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/plasma-pa.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:plasma-pa</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/plasma-pa/plasma-pa-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/plasma-pa</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/plasma-pa</url>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>canberra</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="libkscreen">
+        <name>libkscreen</name>
+        <description>KDE's screen management software</description>
+        <icon/>
+        <path>kde/workspace/libkscreen</path>
+        <web>https://cgit.kde.org/libkscreen.git</web>
+        <member username="sebas">Sebastian Kügler</member>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="afiestas">Àlex Fiestas</member>
+        <member username="dvratil">Dan Vrátil</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/libkscreen.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:libkscreen</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/libkscreen/libkscreen-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/libkscreen</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/libkscreen</url>
+          <branch>Plasma/5.0</branch>
+          <branch>Plasma/5.1</branch>
+          <branch>Plasma/5.2</branch>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>bug353720</branch>
+          <branch>david/allthedebug</branch>
+          <branch>david/fixedit</branch>
+          <branch>graesslin/resource-changed</branch>
+          <branch>ipmerge</branch>
+          <branch>kdelibs4</branch>
+          <branch>kwinEffect</branch>
+          <branch>master</branch>
+          <branch>sebas/doctor</branch>
+          <branch>sebas/dpms</branch>
+          <branch>sebas/drm</branch>
+          <branch>sebas/dynmodes</branch>
+          <branch>sebas/features</branch>
+          <branch>sebas/inprocess</branch>
+          <branch>sebas/inprocess-merge</branch>
+          <branch>sebas/log</branch>
+          <branch>sebas/modelistchange</branch>
+          <branch>sebas/qscreen</branch>
+          <branch>sebas/wayland</branch>
+          <branch>sebas/wayland-default</branch>
+          <branch>sebas/waylandscreenmanagement</branch>
+          <branch i18n="trunk">kdelibs4</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="libksysguard">
+        <name>libksysguard</name>
+        <description></description>
+        <icon/>
+        <path>kde/workspace/libksysguard</path>
+        <web>https://cgit.kde.org/libksysguard.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="afiestas">Àlex Fiestas</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/libksysguard.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:libksysguard</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/libksysguard/libksysguard-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/libksysguard</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/libksysguard</url>
+          <branch>Plasma/5.0</branch>
+          <branch>Plasma/5.1</branch>
+          <branch>Plasma/5.2</branch>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="sddm-kcm">
+        <name>SDDM KCM</name>
+        <description>Config module for SDDM</description>
+        <icon/>
+        <path>kde/workspace/sddm-kcm</path>
+        <web>https://cgit.kde.org/sddm-kcm.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="davidedmundson">David Edmundson</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/sddm-kcm.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:sddm-kcm</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/sddm-kcm/sddm-kcm-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/sddm-kcm</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/sddm-kcm</url>
+          <branch>Plasma/5.2</branch>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>asynchronous-save</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="ksysguard">
+        <name>ksysguard</name>
+        <description></description>
+        <icon/>
+        <path>kde/workspace/ksysguard</path>
+        <web>https://cgit.kde.org/ksysguard.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="afiestas">Àlex Fiestas</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/ksysguard.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:ksysguard</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/ksysguard/ksysguard-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/ksysguard</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/ksysguard</url>
+          <branch>Plasma/5.0</branch>
+          <branch>Plasma/5.1</branch>
+          <branch>Plasma/5.2</branch>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="plasma-integration">
+        <name>Integration for Qt applications in Plasma</name>
+        <description>Qt Platform Theme integration plugins for the Plasma workspaces.</description>
+        <icon/>
+        <path>kde/workspace/plasma-integration</path>
+        <web>https://cgit.kde.org/plasma-integration.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="mart">Marco Martin</member>
+        <member username="sebas">Sebastian Kügler</member>
+        <member username="graesslin">Martin Gräßlin</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/plasma-integration.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:plasma-integration</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/plasma-integration/plasma-integration-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/plasma-integration</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/plasma-integration</url>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="plasma-workspace-wallpapers">
+        <name>Plasma Workspace Wallpapers</name>
+        <description>Wallpapers for the Plasma Workspace</description>
+        <icon/>
+        <path>kde/workspace/plasma-workspace-wallpapers</path>
+        <web>https://cgit.kde.org/plasma-workspace-wallpapers.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="sitter">Harald Sitter</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/plasma-workspace-wallpapers.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:plasma-workspace-wallpapers</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/plasma-workspace-wallpapers/plasma-workspace-wallpapers-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/plasma-workspace-wallpapers</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/plasma-workspace-wallpapers</url>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="kde-gtk-config">
+        <name>KDE GTK Configurator</name>
+        <description>GTK2 and GTK3 Configurator for KDE.
+
+Configuration dialog to adapt GTK applications appearance to your taste under KDE. Among its many features, it lets you:
+ - Choose which theme is used for GTK2 and GTK3 applications.
+ - Tweak some GTK applications behaviour.
+ - Select what icon theme to use in GTK applications.
+ - Select GTK applications default fonts.
+ - Easily browse and install new GTK2 and GTK3 themes.</description>
+        <icon/>
+        <path>kde/workspace/kde-gtk-config</path>
+        <web>https://cgit.kde.org/kde-gtk-config.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="sanchezreynaga">José Antonio Sánchez Reynaga</member>
+        <member username="manutortosa">Manuel Tortosa</member>
+        <member username="apol">Aleix Pol Gonzalez</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/kde-gtk-config.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:kde-gtk-config</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/kde-gtk-config/kde-gtk-config-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/kde-gtk-config</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/kde-gtk-config</url>
+          <branch>2.1</branch>
+          <branch>2.2</branch>
+          <branch>Plasma/5.2</branch>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>frameworks</branch>
+          <branch>master</branch>
+          <branch>newui</branch>
+          <branch>xembed</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">2.2</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="kdecoration">
+        <name>Window Decoration Library</name>
+        <description>Plugin based library to create window decorations</description>
+        <icon/>
+        <path>kde/workspace/kdecoration</path>
+        <web>https://cgit.kde.org/kdecoration.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="graesslin">Martin Gräßlin</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/kdecoration.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:kdecoration</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/kdecoration/kdecoration-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/kdecoration</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/kdecoration</url>
+          <branch>Plasma/5.2</branch>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="plasma-desktop">
+        <name>plasma-desktop</name>
+        <description></description>
+        <icon/>
+        <path>kde/workspace/plasma-desktop</path>
+        <web>https://cgit.kde.org/plasma-desktop.git</web>
+        <member username="afiestas">Àlex Fiestas</member>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="mart">Marco Martin</member>
+        <member username="ivan">Ivan Čukić</member>
+        <member username="davidedmundson">David Edmundson</member>
+        <member username="hein">Eike Hein</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/plasma-desktop.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:plasma-desktop</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/plasma-desktop/plasma-desktop-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/plasma-desktop</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/plasma-desktop</url>
+          <branch>KcmQmlPorts</branch>
+          <branch>Plasma/5.0</branch>
+          <branch>Plasma/5.1</branch>
+          <branch>Plasma/5.2</branch>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>amourphious/als</branch>
+          <branch>amourphious/keyboard</branch>
+          <branch>andriy/keyboard</branch>
+          <branch>davidedmundson/coloured_kicker</branch>
+          <branch>hein/appdash</branch>
+          <branch>hein/fastFolders</branch>
+          <branch>interactiveconsole_in_shellpackage</branch>
+          <branch>ivan/new-favourites-per-activity</branch>
+          <branch>jlayt/translations</branch>
+          <branch>ltinkl/solid-power</branch>
+          <branch>mart/KCModuleQml</branch>
+          <branch>mart/LookAndFeelKCM</branch>
+          <branch>mart/RunnerKCMConfigDialog</branch>
+          <branch>mart/RunnerKCMKPluginLoader</branch>
+          <branch>mart/alternativesConfig</branch>
+          <branch>mart/balookickoff</branch>
+          <branch>mart/basicDeleteUndo</branch>
+          <branch>mart/kcm_cursorthemeQML</branch>
+          <branch>mart/kserviceaction</branch>
+          <branch>mart/ksplashkcmexperiment</branch>
+          <branch>mart/lookAndFeelGHNS</branch>
+          <branch>mart/lookandfeelghns</branch>
+          <branch>mart/ocsMigration</branch>
+          <branch>mart/singleQmlEngineExperiment</branch>
+          <branch>master</branch>
+          <branch>sebas/locale</branch>
+          <branch>sebas/wayland</branch>
+          <branch>user-accounts</branch>
+          <branch>vhanda/runnersKcm</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="powerdevil">
+        <name>PowerDevil</name>
+        <description>Manages the power consumption settings of a Plasma Shell</description>
+        <icon/>
+        <path>kde/workspace/powerdevil</path>
+        <web>https://cgit.kde.org/powerdevil.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="afiestas">Àlex Fiestas</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/powerdevil.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:powerdevil</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/powerdevil/powerdevil-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/powerdevil</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/powerdevil</url>
+          <branch>Plasma/5.0</branch>
+          <branch>Plasma/5.1</branch>
+          <branch>Plasma/5.2</branch>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>broulik/5.5</branch>
+          <branch>broulik/activityConfig</branch>
+          <branch>broulik/ddccontrol</branch>
+          <branch>broulik/ddcontrol</branch>
+          <branch>broulik/exposeInhibitions</branch>
+          <branch>broulik/lidActionExternalMonitor</branch>
+          <branch>broulik/nolowbatteryprofile</branch>
+          <branch>broulik/notifyPeripherals</branch>
+          <branch>bshah/dpms-brightness-zero</branch>
+          <branch>ltinkl/solid-power</branch>
+          <branch>master</branch>
+          <branch>sebas/kcmupdates</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="kmenuedit">
+        <name>kmenuedit</name>
+        <description></description>
+        <icon/>
+        <path>kde/workspace/kmenuedit</path>
+        <web>https://cgit.kde.org/kmenuedit.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="afiestas">Àlex Fiestas</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/kmenuedit.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:kmenuedit</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/kmenuedit/kmenuedit-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/kmenuedit</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/kmenuedit</url>
+          <branch>Plasma/5.0</branch>
+          <branch>Plasma/5.1</branch>
+          <branch>Plasma/5.2</branch>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="breeze-grub">
+        <name>Breeze Grub visual style</name>
+        <description>Grub theme for the Breeze visual style for the Plasma Desktop</description>
+        <icon/>
+        <path>kde/workspace/breeze-grub</path>
+        <web>https://cgit.kde.org/breeze-grub.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="andreask">Andreas Kainz</member>
+        <member username="alake">Andrew Lake</member>
+        <member username="mart">Marco Martin</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/breeze-grub.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:breeze-grub</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/breeze-grub/breeze-grub-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/breeze-grub</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/breeze-grub</url>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="plasma-workspace">
+        <name>plasma-workspace</name>
+        <description></description>
+        <icon/>
+        <path>kde/workspace/plasma-workspace</path>
+        <web>https://cgit.kde.org/plasma-workspace.git</web>
+        <member username="davidedmundson">David Edmundson</member>
+        <member username="ivan">Ivan Čukić</member>
+        <member username="mart">Marco Martin</member>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="afiestas">Àlex Fiestas</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/plasma-workspace.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:plasma-workspace</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/plasma-workspace/plasma-workspace-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/plasma-workspace</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/plasma-workspace</url>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="kwrited">
+        <name>kwrited</name>
+        <description></description>
+        <icon/>
+        <path>kde/workspace/kwrited</path>
+        <web>https://cgit.kde.org/kwrited.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="afiestas">Àlex Fiestas</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/kwrited.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:kwrited</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/kwrited/kwrited-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/kwrited</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/kwrited</url>
+          <branch>Plasma/5.0</branch>
+          <branch>Plasma/5.1</branch>
+          <branch>Plasma/5.2</branch>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="kwallet-pam">
+        <name>KWallet PAM Integration</name>
+        <description></description>
+        <icon/>
+        <path>kde/workspace/kwallet-pam</path>
+        <web>https://cgit.kde.org/kwallet-pam.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="afiestas">Àlex Fiestas</member>
+        <member username="mklapetek">Martin Klapetek</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/kwallet-pam.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:kwallet-pam</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/kwallet-pam/kwallet-pam-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/kwallet-pam</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/kwallet-pam</url>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="plasma-nm">
+        <name>Plasma applet for NetworkManager</name>
+        <description>Plasma applet written in QML for managing network connections</description>
+        <icon/>
+        <path>kde/workspace/plasma-nm</path>
+        <web>https://cgit.kde.org/plasma-nm.git</web>
+        <member username="grulich">Jan Grulich</member>
+        <member username="lukas">Lukáš Tinkl</member>
+        <member username="dantti">Daniel Nicoletti</member>
+        <member username="lvsouza">Lamarque Souza</member>
+        <member username="jriddell">Jonathan Riddell</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/plasma-nm.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:plasma-nm</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/plasma-nm/plasma-nm-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/plasma-nm</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/plasma-nm</url>
+          <branch>0.9.3</branch>
+          <branch>Plasma/5.0</branch>
+          <branch>Plasma/5.1</branch>
+          <branch>Plasma/5.2</branch>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>active</branch>
+          <branch>editor-qml</branch>
+          <branch>kcm</branch>
+          <branch>kcm-qml</branch>
+          <branch>master</branch>
+          <branch>plasma-kcm</branch>
+          <branch>refactor-8021x</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">0.9.3</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="kscreenlocker">
+        <name>KScreenLocker</name>
+        <description>Library and components for secure lock screen architecture.</description>
+        <icon/>
+        <path>kde/workspace/kscreenlocker</path>
+        <web>https://cgit.kde.org/kscreenlocker.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="bshah">Bhushan Shah</member>
+        <member username="graesslin">Martin Gräßlin</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/kscreenlocker.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:kscreenlocker</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/kscreenlocker/kscreenlocker-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/kscreenlocker</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/kscreenlocker</url>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="kwin">
+        <name>kwin</name>
+        <description>KWin is an easy to use, but flexible, composited Window Manger for Xorg windowing systems on Linux. Its primary usage is in conjunction with a Shell (e.g. KDE Plasma Desktop). KWin is designed to go out of the way; users should not notice that they use a window manager at all. Nevertheless KWin provides a steep learning curve for advanced features, which are available, if they do not conflict with the primary mission. KWin does not have a dedicated targeted user group, but follows the targeted user group of the Desktop Shell using KWin as it's Window Manager.</description>
+        <icon/>
+        <path>kde/workspace/kwin</path>
+        <web>https://cgit.kde.org/kwin.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="graesslin">Martin Gräßlin</member>
+        <member username="afiestas">Àlex Fiestas</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/kwin.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:kwin</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/kwin/kwin-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/kwin</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/kwin</url>
+          <branch>Plasma/5.0</branch>
+          <branch>Plasma/5.1</branch>
+          <branch>Plasma/5.2</branch>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>bshah/hwcomposer_testing</branch>
+          <branch>graesslin/kdecoration2</branch>
+          <branch>graesslin/sharing-platform-context-no-surfaceless</branch>
+          <branch>graesslin/virtual-keyboard</branch>
+          <branch>graesslin/x11cursor-to-platform</branch>
+          <branch>graesslin/xdg-shell</branch>
+          <branch>hybris-remove-brightnesshandling</branch>
+          <branch>input-device-dbus</branch>
+          <branch>mart/blurProtocol</branch>
+          <branch>mart/morphingpopups</branch>
+          <branch>master</branch>
+          <branch>sebas/outputmanagement</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="oxygen">
+        <name>oxygen</name>
+        <description></description>
+        <icon/>
+        <path>kde/workspace/oxygen</path>
+        <web>https://cgit.kde.org/oxygen.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="afiestas">Àlex Fiestas</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/oxygen.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:oxygen</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/oxygen/oxygen-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/oxygen</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/oxygen</url>
+          <branch>Plasma/5.0</branch>
+          <branch>Plasma/5.1</branch>
+          <branch>Plasma/5.2</branch>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>hpereira/breeze</branch>
+          <branch>kdecoration2</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="plasma-tests">
+        <name>Plasma Tests</name>
+        <description>Tests for the Plasma Workspace</description>
+        <icon/>
+        <path>kde/workspace/plasma-tests</path>
+        <web>https://cgit.kde.org/plasma-tests.git</web>
+        <member username="graesslin">Martin Gräßlin</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/plasma-tests.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:plasma-tests</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/plasma-tests/plasma-tests-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/plasma-tests</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/plasma-tests</url>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="kscreen">
+        <name>KScreen</name>
+        <description>KDE's screen management software</description>
+        <icon/>
+        <path>kde/workspace/kscreen</path>
+        <web>https://cgit.kde.org/kscreen.git</web>
+        <member username="sebas">Sebastian Kügler</member>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="afiestas">Àlex Fiestas</member>
+        <member username="dvratil">Dan Vrátil</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/kscreen.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:kscreen</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/kscreen/kscreen-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/kscreen</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/kscreen</url>
+          <branch>Plasma/5.2</branch>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>aseigo/configUI</branch>
+          <branch>davidedmundson/highdpi_select</branch>
+          <branch>dvratil/laptopLid</branch>
+          <branch>identicalmonitors2</branch>
+          <branch>kded</branch>
+          <branch>kdelibs4</branch>
+          <branch>master</branch>
+          <branch>osd</branch>
+          <branch>plasma-applet</branch>
+          <branch>powerDevil</branch>
+          <branch>sebas/configmodule</branch>
+          <branch>sebas/dynmodes</branch>
+          <branch>sebas/identicalmonitors2</branch>
+          <branch>sebas/osd</branch>
+          <branch i18n="trunk">kdelibs4</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="systemsettings">
+        <name>systemsettings</name>
+        <description></description>
+        <icon/>
+        <path>kde/workspace/systemsettings</path>
+        <web>https://cgit.kde.org/systemsettings.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="afiestas">Àlex Fiestas</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/systemsettings.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:systemsettings</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/systemsettings/systemsettings-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/systemsettings</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/systemsettings</url>
+          <branch>Plasma/5.0</branch>
+          <branch>Plasma/5.1</branch>
+          <branch>Plasma/5.2</branch>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>davidedmundson/newdesign</branch>
+          <branch>master</branch>
+          <branch>newcategories</branch>
+          <branch>sebas/quick</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="plasma-vault">
+        <name>Plasma Vault</name>
+        <description>Plasma applet and services for creating encrypted vaults</description>
+        <icon/>
+        <path>kde/workspace/plasma-vault</path>
+        <web>https://cgit.kde.org/plasma-vault.git</web>
+        <member username="ivan">Ivan Čukić</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/plasma-vault.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:plasma-vault</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/plasma-vault/plasma-vault-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/plasma-vault</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/plasma-vault</url>
+          <branch>ivan/tomb-support</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">none</branch>
+        </repo>
+      </project>
+      <project identifier="kinfocenter">
+        <name>kinfocenter</name>
+        <description></description>
+        <icon/>
+        <path>kde/workspace/kinfocenter</path>
+        <web>https://cgit.kde.org/kinfocenter.git</web>
+        <member username="mart">Marco Martin</member>
+        <member username="davidedmundson">David Edmundson</member>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="afiestas">Àlex Fiestas</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/kinfocenter.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:kinfocenter</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/kinfocenter/kinfocenter-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/kinfocenter</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/kinfocenter</url>
+          <branch>Plasma/5.0</branch>
+          <branch>Plasma/5.1</branch>
+          <branch>Plasma/5.2</branch>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>energyInfo</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="plasma-sdk">
+        <name>Plasma SDK</name>
+        <description>Applications useful for Plasma Development.</description>
+        <icon>plasmagik</icon>
+        <path>kde/workspace/plasma-sdk</path>
+        <web>https://cgit.kde.org/plasma-sdk.git</web>
+        <member username="sebas">Sebastian Kügler</member>
+        <member username="casella">Diego Casella</member>
+        <member username="tsiapaliokas">Antonis Tsiapaliokas</member>
+        <member username="tsiapaliwkas">Giorgos Tsiapaliokas</member>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="mart">Marco Martin</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/plasma-sdk.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:plasma-sdk</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/plasma-sdk/plasma-sdk-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/plasma-sdk</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/plasma-sdk</url>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>frameworks_plasmate_startpage</branch>
+          <branch>graesslin/rebased-auroraepreviewer</branch>
+          <branch>kokeroulis/auroraepreviewer</branch>
+          <branch>mart/AppletComponent</branch>
+          <branch>mart/modelsInDataEngine</branch>
+          <branch>mart/plasmaThemeCreate</branch>
+          <branch>mart/plasmathemeexplorer</branch>
+          <branch>master</branch>
+          <branch>plasmate/1.0</branch>
+          <branch>plasmate/cmake_install_functionality</branch>
+          <branch>plasmate/frameworks</branch>
+          <branch>terietor/kdevplatform</branch>
+          <branch>terietor/mainwindow/build</branch>
+          <branch>terietor/porting</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="kdeplasma-addons">
+        <name>Plasma Addons</name>
+        <description>All kind of addons to improve your Plasma experience</description>
+        <icon/>
+        <path>kde/workspace/kdeplasma-addons</path>
+        <web>https://cgit.kde.org/kdeplasma-addons.git</web>
+        <member username="aacid">Albert Astals Cid</member>
+        <member username="asouza">Artur Duque de Souza</member>
+        <member username="aseigo">Aaron J. Seigo</member>
+        <member username="mart">Marco Martin</member>
+        <member username="ianmonroe">Ian Monroe</member>
+        <member username="davidedmundson">David Edmundson</member>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="hein">Eike Hein</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/kdeplasma-addons.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:kdeplasma-addons</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/kdeplasma-addons/kdeplasma-addons-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/kdeplasma-addons</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/kdeplasma-addons</url>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="kactivitymanagerd">
+        <name>Activity manager service</name>
+        <description>System service to manage user's activities, track the usage patterns etc.</description>
+        <icon>preferences-activities</icon>
+        <path>kde/workspace/kactivitymanagerd</path>
+        <web>https://cgit.kde.org/kactivitymanagerd.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="ivan">Ivan Čukić</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/kactivitymanagerd.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:kactivitymanagerd</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/kactivitymanagerd/kactivitymanagerd-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/kactivitymanagerd</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/kactivitymanagerd</url>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="bluedevil">
+        <name>Bluedevil</name>
+        <description>Bluedevil is a project which intends to integrate the Bluetooth technology within KDE workspace and applications.
+
+These are the components of BlueDevil:
+* SystemSettings integration
+* Systemtray application
+* Wizard to setup Bluetooth devices (Mouses, Keyboards...)
+* Send/Receive files
+* KIO integration (ability to browse Devices and their files)</description>
+        <icon/>
+        <path>kde/workspace/bluedevil</path>
+        <web>https://cgit.kde.org/bluedevil.git</web>
+        <member username="drosca">David Rosca</member>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="ereslibre">Rafael Fernández López</member>
+        <member username="afiestas">Àlex Fiestas</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/bluedevil.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:bluedevil</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/bluedevil/bluedevil-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/bluedevil</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/bluedevil</url>
+          <branch>1.0</branch>
+          <branch>1.1</branch>
+          <branch>1.2</branch>
+          <branch>1.3</branch>
+          <branch>Plasma/5.2</branch>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>alex_forgets_things</branch>
+          <branch>betterMonolithicHandling</branch>
+          <branch>bluez5</branch>
+          <branch>bluezqt</branch>
+          <branch>filereceive-bluez5</branch>
+          <branch>kdelibs</branch>
+          <branch>master</branch>
+          <branch>obexd-server</branch>
+          <branch>obexftp-bluez5</branch>
+          <branch>qbluez</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="kwayland-integration">
+        <name>Frameworks integration plugin using KWayland</name>
+        <description>Provides integration plugins for various KDE frameworks for the wayland windowing system.</description>
+        <icon/>
+        <path>kde/workspace/kwayland-integration</path>
+        <web>https://cgit.kde.org/kwayland-integration.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="graesslin">Martin Gräßlin</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/kwayland-integration.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:kwayland-integration</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/kwayland-integration/kwayland-integration-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/kwayland-integration</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/kwayland-integration</url>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>mart/blurProtocol</branch>
+          <branch>mart/singleWaylandConnection</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="breeze-gtk">
+        <name>Breeze for Gtk</name>
+        <description>Widget theme for GTK 2 and 3</description>
+        <icon/>
+        <path>kde/workspace/breeze-gtk</path>
+        <web>https://cgit.kde.org/breeze-gtk.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="davidedmundson">David Edmundson</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/breeze-gtk.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:breeze-gtk</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/breeze-gtk/breeze-gtk-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/breeze-gtk</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/breeze-gtk</url>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="user-manager">
+        <name>user-manager</name>
+        <description>A simple system settings module to manage the users of your system</description>
+        <icon/>
+        <path>kde/workspace/user-manager</path>
+        <web>https://cgit.kde.org/user-manager.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="afiestas">Àlex Fiestas</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/user-manager.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:user-manager</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/user-manager/user-manager-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/user-manager</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/user-manager</url>
+          <branch>Plasma/5.2</branch>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>changePassword</branch>
+          <branch>frameworks</branch>
+          <branch>master</branch>
+          <branch>password-embedded</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="milou">
+        <name>Milou</name>
+        <description>A dedicated search application built on top of Baloo</description>
+        <icon>nepomuk</icon>
+        <path>kde/workspace/milou</path>
+        <web>https://cgit.kde.org/milou.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="vhanda">Vishesh Handa</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/milou.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:milou</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/milou/milou-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/milou</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/milou</url>
+          <branch>Plasma/5.0</branch>
+          <branch>Plasma/5.1</branch>
+          <branch>Plasma/5.2</branch>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>master</branch>
+          <branch>milou/0.1</branch>
+          <branch>okularQMlPreviews</branch>
+          <branch>previews</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">milou/0.1</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="kgamma5">
+        <name>KGamma</name>
+        <description>Adjust your monitor's gamma settings</description>
+        <icon/>
+        <path>kde/workspace/kgamma5</path>
+        <web>https://cgit.kde.org/kgamma5.git</web>
+        <member username="davidedmundson">David Edmundson</member>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="mwiesweg">Marcel Wiesweg</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/kgamma5.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:kgamma5</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/kgamma5/kgamma5-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/kgamma5</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/kgamma5</url>
+          <branch>Applications/14.12</branch>
+          <branch>Applications/15.04</branch>
+          <branch>KDE/3.2</branch>
+          <branch>KDE/3.3</branch>
+          <branch>KDE/3.4</branch>
+          <branch>KDE/3.5</branch>
+          <branch>KDE/4.0</branch>
+          <branch>KDE/4.1</branch>
+          <branch>KDE/4.10</branch>
+          <branch>KDE/4.11</branch>
+          <branch>KDE/4.12</branch>
+          <branch>KDE/4.13</branch>
+          <branch>KDE/4.14</branch>
+          <branch>KDE/4.2</branch>
+          <branch>KDE/4.3</branch>
+          <branch>KDE/4.4</branch>
+          <branch>KDE/4.5</branch>
+          <branch>KDE/4.6</branch>
+          <branch>KDE/4.7</branch>
+          <branch>KDE/4.8</branch>
+          <branch>KDE/4.9</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>frameworks</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="breeze">
+        <name>Plasma Breeze visual style</name>
+        <description>Artwork, styles and assets for the Breeze visual style for the Plasma Desktop</description>
+        <icon/>
+        <path>kde/workspace/breeze</path>
+        <web>https://cgit.kde.org/breeze.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="alake">Andrew Lake</member>
+        <member username="mart">Marco Martin</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/breeze.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:breeze</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/breeze/breeze-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/breeze</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/breeze</url>
+          <branch>Plasma/5.0</branch>
+          <branch>Plasma/5.1</branch>
+          <branch>Plasma/5.2</branch>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>davidedmundson/kde4stylehints</branch>
+          <branch>graesslin/kdecoration2</branch>
+          <branch>hpereira/kwin-decoration</branch>
+          <branch>jriddell/gtkbreeze</branch>
+          <branch>jriddell/plymouth</branch>
+          <branch>mart/kde4breeze</branch>
+          <branch>master</branch>
+          <branch>working</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="ksshaskpass">
+        <name>KSSHAskPass</name>
+        <description>ssh-add helper that uses kwallet and kpassworddialog</description>
+        <icon/>
+        <path>kde/workspace/ksshaskpass</path>
+        <web>https://cgit.kde.org/ksshaskpass.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="whiting">Jeremy Whiting</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/ksshaskpass.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:ksshaskpass</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/ksshaskpass/ksshaskpass-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/ksshaskpass</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/ksshaskpass</url>
+          <branch>Plasma/5.2</branch>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="kde-cli-tools">
+        <name>KDE CLI tools</name>
+        <description>Tools based on KDE Frameworks 5 to better interact with the system.</description>
+        <icon/>
+        <path>kde/workspace/kde-cli-tools</path>
+        <web>https://cgit.kde.org/kde-cli-tools.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="apol">Aleix Pol Gonzalez</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/kde-cli-tools.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:kde-cli-tools</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/kde-cli-tools/kde-cli-tools-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/kde-cli-tools</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/kde-cli-tools</url>
+          <branch>Plasma/5.0</branch>
+          <branch>Plasma/5.1</branch>
+          <branch>Plasma/5.2</branch>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>frameworks</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="khotkeys">
+        <name>khotkeys</name>
+        <description></description>
+        <icon/>
+        <path>kde/workspace/khotkeys</path>
+        <web>https://cgit.kde.org/khotkeys.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="afiestas">Àlex Fiestas</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/khotkeys.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:khotkeys</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/khotkeys/khotkeys-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/khotkeys</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/khotkeys</url>
+          <branch>Plasma/5.0</branch>
+          <branch>Plasma/5.1</branch>
+          <branch>Plasma/5.2</branch>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="breeze-plymouth">
+        <name>Breeze Plymouth visual style</name>
+        <description>Plymouth theme for the Breeze visual style for the Plasma Desktop</description>
+        <icon/>
+        <path>kde/workspace/breeze-plymouth</path>
+        <web>https://cgit.kde.org/breeze-plymouth.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="andreask">Andreas Kainz</member>
+        <member username="alake">Andrew Lake</member>
+        <member username="mart">Marco Martin</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/breeze-plymouth.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:breeze-plymouth</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/breeze-plymouth/breeze-plymouth-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/breeze-plymouth</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/breeze-plymouth</url>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+      <project identifier="polkit-kde-agent-1">
+        <name>Polkit KDE Agent</name>
+        <description>Daemon providing a polkit authentication UI for KDE.
+
+Please be sure to read and follow "the polkit-KDE contribution and development guidelines":http://techbase.kde.org/Polkit-KDE_development_guidelines to contribute code.</description>
+        <icon/>
+        <path>kde/workspace/polkit-kde-agent-1</path>
+        <web>https://cgit.kde.org/polkit-kde-agent-1.git</web>
+        <member username="jriddell">Jonathan Riddell</member>
+        <member username="jreznik">Jaroslav Řezník</member>
+        <member username="dafre">Dario Freddi</member>
+        <member username="mbriza">Martin Bříza</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/polkit-kde-agent-1.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:polkit-kde-agent-1</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/polkit-kde-agent-1/polkit-kde-agent-1-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/polkit-kde-agent-1</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/polkit-kde-agent-1</url>
+          <branch>Plasma/5.2</branch>
+          <branch>Plasma/5.3</branch>
+          <branch>Plasma/5.4</branch>
+          <branch>Plasma/5.5</branch>
+          <branch>Plasma/5.6</branch>
+          <branch>Plasma/5.7</branch>
+          <branch>Plasma/5.8</branch>
+          <branch>Plasma/5.9</branch>
+          <branch>frameworks</branch>
+          <branch>kdelibs4</branch>
+          <branch>master</branch>
+          <branch i18n="trunk">kdelibs4</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">master</branch>
+          <branch i18n="stable_kf5">Plasma/5.9</branch>
+        </repo>
+      </project>
+    </module>
+  </component>
+</kdeprojects>

--- a/ci-tooling/test/data/kde_projects_stripped.xml
+++ b/ci-tooling/test/data/kde_projects_stripped.xml
@@ -1763,6 +1763,48 @@ Report bugs in bugs.kde.org, under product frameworks-networkmanager-qt.</descri
       <icon/>
       <path>kde/applications</path>
       <web/>
+      <project identifier="no-stable">
+        <name>Dolphin</name>
+        <description>KDE File Manager</description>
+        <icon/>
+        <path>kde/applications/no-stable</path>
+        <web>https://cgit.kde.org/dolphin.git</web>
+        <member username="freininghaus">Frank Reininghaus</member>
+        <member username="emmanuelp">Emmanuel Pescosta</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/no-stable.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:no-stable</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/no-stable/no-stable-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/no-stable</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/no-stable</url>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">supertrunk</branch>
+          <branch i18n="stable_kf5">none</branch>
+        </repo>
+      </project>
+      <project identifier="no-i18n">
+        <name>Dolphin</name>
+        <description>KDE File Manager</description>
+        <icon/>
+        <path>kde/applications/no-stable</path>
+        <web>https://cgit.kde.org/dolphin.git</web>
+        <member username="freininghaus">Frank Reininghaus</member>
+        <member username="emmanuelp">Emmanuel Pescosta</member>
+        <repo>
+          <active>true</active>
+          <web type="gitweb">https://cgit.kde.org/no-i18n.git</web>
+          <url protocol="ssh" access="read+write">git@git.kde.org:no-i18n</url>
+          <url protocol="tarball" access="read-only">http://anongit.kde.org/no-i18n/no-i18n-latest.tar.gz</url>
+          <url protocol="git" access="read-only">git://anongit.kde.org/no-i18n</url>
+          <url protocol="http" access="read-only">http://anongit.kde.org/no-i18n</url>
+          <branch i18n="trunk">none</branch>
+          <branch i18n="stable">none</branch>
+          <branch i18n="trunk_kf5">none</branch>
+          <branch i18n="stable_kf5">none</branch>
+        </repo>
+      </project>
       <project identifier="dolphin">
         <name>Dolphin</name>
         <description>KDE File Manager</description>

--- a/ci-tooling/test/lib/testcase.rb
+++ b/ci-tooling/test/lib/testcase.rb
@@ -1,6 +1,6 @@
 require 'test/unit'
 require 'tmpdir'
-require 'webmock'
+require 'webmock/test_unit'
 
 require_relative 'assert_xml'
 
@@ -73,6 +73,10 @@ EOT
     reset_child_status!
     #FIXME: Drop when VCR gets fixed
     WebMock.enable!
+
+    stub_request(:get, 'https://projects.kde.org/kde_projects.xml')
+      .to_return(body:
+         File.read("#{script_base_path}/data/kde_projects_stripped.xml"))
   end
 
   def priority_teardown

--- a/ci-tooling/test/test_projects_factory.rb
+++ b/ci-tooling/test/test_projects_factory.rb
@@ -308,7 +308,8 @@ hello sitter, this is gitolite3@weegie running gitolite3 3.6.1-3 (Debian) on git
                              name: 'qtbase',
                              component: 'qt',
                              url_base: neon_dir,
-                             branch: 'kubuntu_unstable')]
+                             branch: 'kubuntu_unstable',
+                             origin: nil)]
 
     refute_nil(projects)
     assert_equal(1, projects.size)

--- a/ci-tooling/test/test_upstream_scm.rb
+++ b/ci-tooling/test/test_upstream_scm.rb
@@ -1,12 +1,56 @@
+# frozen_string_literal: true
+#
+# Copyright (C) 2014-2017 Harald Sitter <sitter@kde.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) version 3, or any
+# later version accepted by the membership of KDE e.V. (or its
+# successor approved by the membership of KDE e.V.), which shall
+# act as a proxy defined in Section 6 of version 3 of the license.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
 require_relative '../lib/ci/upstream_scm'
 require_relative 'lib/testcase'
 
 # Test ci/upstream_scm
 class UpstreamSCMTest < TestCase
   def test_defaults
-    scm = UpstreamSCM.new('breeze-qt4', 'kubuntu_unstable', '/')
+    scm = CI::UpstreamSCM.new('breeze-qt4', 'kubuntu_unstable', '/')
     assert_equal('git', scm.type)
     assert_equal('git://anongit.kde.org/breeze', scm.url)
+    assert_equal('master', scm.branch)
+  end
+
+  def test_releasme_adjust
+    scm = CI::UpstreamSCM.new('breeze-qt4', 'kubuntu_unstable', '/')
+    assert_equal('git', scm.type)
+    assert_equal('git://anongit.kde.org/breeze', scm.url)
+    assert_equal('master', scm.branch)
+    scm.releaseme_adjust!(CI::UpstreamSCM::Origin::STABLE)
+    assert_equal('git', scm.type)
+    assert_equal('git://anongit.kde.org/breeze', scm.url)
+    assert_equal('Plasma/5.9', scm.branch)
+  end
+
+  def test_releasme_adjust_uninteresting
+    # Not changing non kde.org stuff.
+    scm = CI::UpstreamSCM.new('breeze-qt4', 'kubuntu_unstable', '/')
+    assert_equal('git', scm.type)
+    assert_equal('git://anongit.kde.org/breeze', scm.url)
+    assert_equal('master', scm.branch)
+    scm.instance_variable_set(:@url, 'git://kittens')
+    assert_nil(scm.releaseme_adjust!(CI::UpstreamSCM::Origin::STABLE))
+    assert_equal('git', scm.type)
+    assert_equal('git://kittens', scm.url)
     assert_equal('master', scm.branch)
   end
 end

--- a/ci-tooling/test/test_upstream_scm.rb
+++ b/ci-tooling/test/test_upstream_scm.rb
@@ -53,4 +53,27 @@ class UpstreamSCMTest < TestCase
     assert_equal('git://kittens', scm.url)
     assert_equal('master', scm.branch)
   end
+
+  def test_unknown_url
+    # URL is on KDE but for some reason not in the projects. Should not implode.
+    scm = CI::UpstreamSCM.new('bububbreeze-qt4', 'kubuntu_unstable', '/')
+    assert_nil(scm.releaseme_adjust!(CI::UpstreamSCM::Origin::STABLE))
+  end
+
+  def test_preference_fallback
+    # A special fake thing 'no-stable' should come back with master as no
+    # stable branch is set.
+    scm = CI::UpstreamSCM.new('no-stable', 'kubuntu_unstable', '/')
+    scm.releaseme_adjust!(CI::UpstreamSCM::Origin::STABLE)
+    assert_equal('supertrunk', scm.branch)
+  end
+
+  def test_preference_default
+    # A special fake thing 'no-i18n' should come back with master as no
+    # stable branch is set and no trunk branch is set, i.e. releaseme has no
+    # data to give us.
+    scm = CI::UpstreamSCM.new('no-i18n', 'kubuntu_unstable', '/')
+    scm.releaseme_adjust!(CI::UpstreamSCM::Origin::STABLE)
+    assert_equal('master', scm.branch)
+  end
 end


### PR DESCRIPTION
Project.new has a new param 'origin' this origin is pretty much equal to
the concept of a releaseme origin in that it specifies the quality level
of the project at hand (NB: project == job really, awkward naming and all).
The origin is passed and directly influences the upstream_scm's branch
by resolving the upstream_scm.url through releasme and then picking a
releaseme i18n branch according to our origin (e.g.. when working on a
stable origin project we pick the branch associated with stable i18n).

The origin defaults to unstable (which results in *almost* the same
behavior as before), but can be overridden by setting
```
origin: stable
```
in the projects .yml config. This is extracted by the factorizer and then
passed through the factory into Projects.new where it will be passed to
upstream_scm.

The entire thing only becomes active when the upstream_scm branch was not
overridden from the master default AND the url includes kde.org. i.e. all
of this is noop for !kde projects.

Additionally the branch adjustment only happens after the overrides were
applied. This is to detect a change to the default branch but also to
allow overriding the url. i.e. you can override the upstream_scm.url as
per usual and the new url will be used to conduct the lookup through
releaseme. so, ideally all urls should be resolvable at that point.

To prevent any problems for existing tests that would trigger the relevant
code paths the core testcase now also installs a default stub on the
kde_projects.xml file accessed by releaseme to supply reasonable mock data
that have been stripped from the total data set to plasma+frameworks only
(to save space; full file is 1.5M :O)