### PR TITLE
Enable restricted packaging copy for all of _kde_ build jobs

### DIFF
--- a/ci-tooling/data/settings/nci.yaml
+++ b/ci-tooling/data/settings/nci.yaml
@@ -1,6 +1,6 @@
 # Enable restriction for all of Applications, no one uses gbp there but
 # we have snapcraft.yamls in the tree.
-'*_applications_*':
+'*_kde_*':
   sourcer:
     restricted_packaging_copy: true
 


### PR DESCRIPTION
Previously it was enabled for applications only but they moved to kde/
with salsa move. Another option is to enable it from the sourcer itself
using projects API, but this is simplest